### PR TITLE
Shorten observedAttributes getter

### DIFF
--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -28,15 +28,9 @@ export class LitElement extends HTMLElement {
   }
 
   static get observedAttributes(): string[] {
-    const attrs = [];
-
-    for (const prop in this.properties) {
-      const attrName = this.properties[prop].attrName;
-      if (attrName) {
-        attrs.push(attrName);
-      }
-    }
-    return attrs;
+    return Object.keys(this.properties)
+      .map(key => this.properties[key].attrName)
+      .filter(name => name);
   }
 
   constructor() {


### PR DESCRIPTION
This uses `Array.map` and `Array.filter` to shorten the code inside the observedAttributes getter. It's also more concise IMO.